### PR TITLE
Add `id-length` exception for  `_`

### DIFF
--- a/config.json
+++ b/config.json
@@ -600,6 +600,13 @@
       }
     ],
     "template-curly-spacing": "error",
-    "id-length": "warn"
+    "id-length": [
+      "warn",
+      {
+        "exceptions": [
+          "_"
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Commonly used in `import _ from "lodash";`

This is a personal preference, but I also like to use `_` to indicate that a method variable is required, but not used (it's more of a Ruby convention, but I like it)

for reference: https://eslint.org/docs/rules/id-length#exceptions