### PR TITLE
(feat) Turn requiring JSDoc on as error

### DIFF
--- a/index.json
+++ b/index.json
@@ -550,7 +550,7 @@
     "react/sort-comp": "warn",
     "react/sort-prop-types": "warn",
     "require-jsdoc": [
-      "warn",
+      "error",
       {
         "require": {
           "ArrowFunctionExpression": false,


### PR DESCRIPTION
Not sure why `MethodDefinition` is set to `false` but I left it off.

This shouldn't get merged until the exemption for RC gets merged unless you want to bring everything to a screeching halt.