### PR TITLE
refactor: change prefer-const to error instead of warning

### DIFF
--- a/index.json
+++ b/index.json
@@ -469,7 +469,7 @@
       }
     ],
     "prefer-const": [
-      "warn",
+      "error",
       {
         "destructuring": "any",
         "ignoreReadBeforeAssign": false


### PR DESCRIPTION
All instances of `prefer-const` have been resolved in the core app, therefore we can turn this from a `warning` to an `error` to prevent future issues with this rule.

https://github.com/reactioncommerce/reaction/pull/5290