### PR TITLE
refactor: change max-len to error

### DIFF
--- a/index.json
+++ b/index.json
@@ -200,7 +200,7 @@
     ],
     "keyword-spacing": "error",
     "max-len": [
-      "warn",
+      "error",
       160,
       2,
       {


### PR DESCRIPTION
All `max-len` errors have been fixed in this PR to Reaction, therefore we can update this to be `error` so no further `max-len` violations are introduced.

https://github.com/reactioncommerce/reaction/pull/5296