### PR TITLE
refactor: change id-length to error

### DIFF
--- a/index.json
+++ b/index.json
@@ -147,7 +147,7 @@
     ],
     "guard-for-in": "error",
     "id-length": [
-      "warn",
+      "error",
       {
         "exceptions": [
           "_"


### PR DESCRIPTION
All `id-length` errors have been fixed in this PR to Reaction, therefore we can update this to be `error` so no further `id-length` violations are introduced.

https://github.com/reactioncommerce/reaction/pull/5298