### PR TITLE
refactor: remove consistent-return rule

### DIFF
--- a/index.json
+++ b/index.json
@@ -110,12 +110,6 @@
       "error",
       "never"
     ],
-    "consistent-return": [
-      "warn",
-      {
-        "treatUndefinedAsUnspecified": true
-      }
-    ],
     "curly": [
       "error",
       "multi-line"


### PR DESCRIPTION
The `consistent-return` rule is causing some confusion as to how it is implemented, and doesn't seem to be enforcing what we want it to enforce.

For example, take this function:
```
getCurrentTag() {
    if (this.Router.getRouteName() === "tag") {
      return this.Router.current().params.slug;
    }
  }
```

Even with the option `` enabled, this throws an error. When we try and return `return` or `return undefined, which is what we need this function to return, the error is still thrown.

It seems the rule requires a same-type return, for example a `null` or `string` to be returned, instead of `undefined`.

Because of this confusion, combined with this rule not being one of the `eslint:recommended` rules ([see here](https://eslint.org/docs/rules/)), we are going to remove this rule.