### PR TITLE
feat: make all rules errors instead of warnings

### DIFF
--- a/index.json
+++ b/index.json
@@ -2,6 +2,7 @@
   "parser": "babel-eslint",
   "extends": [
     "plugin:jsx-a11y/recommended",
+    "plugin:node/recommended",
     "plugin:promise/recommended"
   ],
   "env": {

--- a/index.json
+++ b/index.json
@@ -111,7 +111,7 @@
       "never"
     ],
     "consistent-return": [
-      "warn",
+      "error",
       {
         "treatUndefinedAsUnspecified": true
       }
@@ -226,7 +226,7 @@
         "ignoreChainWithDepth": 4
       }
     ],
-    "no-alert": "warn",
+    "no-alert": "error",
     "no-array-constructor": "error",
     "no-await-in-loop": "error",
     "no-bitwise": "error",
@@ -244,8 +244,8 @@
     ],
     "no-console": "error",
     "no-const-assign": "error",
-    "no-constant-condition": "warn",
-    "no-debugger": "warn",
+    "no-constant-condition": "error",
+    "no-debugger": "error",
     "no-dupe-keys": "error",
     "no-duplicate-case": "error",
     "no-else-return": "error",
@@ -512,45 +512,45 @@
         "rule": "^(can|has|is|should)[A-Z]([A-Za-z0-9]?)+"
       }
     ],
-    "react/display-name": "warn",
+    "react/display-name": "error",
     "react/forbid-prop-types": "off",
     "react/jsx-boolean-value": "off",
-    "react/jsx-closing-bracket-location": "warn",
-    "react/jsx-curly-spacing": "warn",
+    "react/jsx-closing-bracket-location": "error",
+    "react/jsx-curly-spacing": "error",
     "react/jsx-indent-props": [
-      "warn",
+      "error",
       2
     ],
     "react/jsx-max-props-per-line": [
-      "warn",
+      "error",
       {
         "maximum": 4
       }
     ],
     "react/jsx-no-bind": "off",
-    "react/jsx-no-duplicate-props": "warn",
+    "react/jsx-no-duplicate-props": "error",
     "react/jsx-no-literals": "off",
-    "react/jsx-no-undef": "warn",
+    "react/jsx-no-undef": "error",
     "react/jsx-sort-props": "off",
-    "react/jsx-uses-react": "warn",
-    "react/jsx-uses-vars": "warn",
-    "react/no-danger": "warn",
-    "react/no-deprecated": "warn",
-    "react/no-did-mount-set-state": "warn",
-    "react/no-did-update-set-state": "warn",
-    "react/no-direct-mutation-state": "warn",
-    "react/no-multi-comp": "warn",
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+    "react/no-danger": "error",
+    "react/no-deprecated": "error",
+    "react/no-did-mount-set-state": "error",
+    "react/no-did-update-set-state": "error",
+    "react/no-direct-mutation-state": "error",
+    "react/no-multi-comp": "error",
     "react/no-set-state": "off",
-    "react/no-unknown-property": "warn",
-    "react/prefer-es6-class": "warn",
-    "react/prop-types": "warn",
+    "react/no-unknown-property": "error",
+    "react/prefer-es6-class": "error",
+    "react/prop-types": "error",
     "react/react-in-jsx-scope": "off",
     "react/require-extension": "off",
-    "react/self-closing-comp": "warn",
-    "react/sort-comp": "warn",
-    "react/sort-prop-types": "warn",
+    "react/self-closing-comp": "error",
+    "react/sort-comp": "error",
+    "react/sort-prop-types": "error",
     "require-jsdoc": [
-      "warn",
+      "error",
       {
         "require": {
           "ArrowFunctionExpression": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactioncommerce/eslint-config",
-  "version": "0.0.0-development",
+  "version": "2.0.0",
   "description": "The ESLint config used by Reaction Commerce, following our style guide",
   "scripts": {},
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,16 +21,17 @@
   "homepage": "https://github.com/reactioncommerce/reaction-eslint-config",
   "dependencies": {},
   "devDependencies": {
-    "semantic-release": "^12.4.1"
+    "semantic-release": "^15.13.19"
   },
   "peerDependencies": {
-    "eslint": ">=4",
+    "eslint": ">=5.16.0",
     "eslint-plugin-import": ">=2",
     "eslint-plugin-jsx-a11y": ">=6",
-    "eslint-plugin-promise": ">=3",
+    "eslint-plugin-node": ">=9",
+    "eslint-plugin-promise": ">=4",
     "eslint-plugin-react": ">=7"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8.1.0"
   }
 }


### PR DESCRIPTION
Resolves #5 
Resolves #7 
Resolves #12 
Resolves #13 

We have cleaned up our codebase enough where all rules are either clean, or are overridden with a `warn` instead of a `error` locally inside of `package.json`. Changing all rules to `error` will guarantee no new eslint issues are introduced in the future.