### PR TITLE
fix: revert package.json version number to allow auto-update via npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactioncommerce/eslint-config",
-  "version": "2.0.0",
+  "version": "0.0.0-development",
   "description": "The ESLint config used by Reaction Commerce, following our style guide",
   "scripts": {},
   "repository": {


### PR DESCRIPTION
Revert package.json version number from `2.0.0` back to `0.0.0-development` to allow npm to handle version on their own. In addition, previous PR updated eslint `warnings` to `errors` which we consider a breaking change for this repo